### PR TITLE
TASK | Fix command-t

### DIFF
--- a/config/osx/init.vim
+++ b/config/osx/init.vim
@@ -39,12 +39,14 @@ call plug#begin("~/.vim/plugged")
   Plug 'jeetsukumaran/vim-buffergator'
   Plug 'kchmck/vim-coffee-script'
   Plug 'mileszs/ack.vim'
+  Plug 'mustache/vim-mustache-handlebars'
   Plug 'pangloss/vim-javascript'
   Plug 'pedrohdz/vim-yaml-folds'
   Plug 'posva/vim-vue'
   Plug 'preservim/nerdcommenter'
   Plug 'preservim/nerdtree'
   Plug 'robitx/gp.nvim'
+  Plug 'towolf/vim-helm'
   Plug 'tpope/vim-endwise'
   Plug 'tpope/vim-fugitive'
   Plug 'tpope/vim-rails'
@@ -96,7 +98,6 @@ let g:vim_json_conceal = 0
 let g:markdown_syntax_conceal=0
 
 let g:CommandTMaxFiles = 80085
-" let g:CommandTPreferredImplementation='lua'
 
 let otl_map_tabs = 1
 let otl_install_menu=1
@@ -291,6 +292,9 @@ lua << EOF
 
     vim.api.nvim_buf_set_lines(0, line1 - 1, line2, false, lines)
   end
+
+  -- Setup/init command-t
+  require('wincent.commandt').setup()
 EOF
 
 command! -range RubocopSort lua RubocopSort(<line1>, <line2>)

--- a/config/osx/init.vim
+++ b/config/osx/init.vim
@@ -295,6 +295,14 @@ lua << EOF
 
   -- Setup/init command-t
   require('wincent.commandt').setup()
+
+  -- Ensure '*/templates/*.yaml' load with helm syntax
+  vim.api.nvim_create_autocmd({'BufNewFile', 'BufRead'}, {
+    pattern = '*/templates/*.yaml',
+    callback = function()
+      vim.opt_local.filetype = 'helm'
+    end,
+  })
 EOF
 
 command! -range RubocopSort lua RubocopSort(<line1>, <line2>)


### PR DESCRIPTION
Latest update to Neovim caused command-t to break. This was due to me failing to initialize it in the init.vim file. This addresses that concern. I also commit a new plugin to handle mustache-handlebars syntax for helm chart templates.